### PR TITLE
fix: Docker 빌드 시 prisma postinstall 스킵

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /app
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 
-# 모든 의존성 설치 (devDependencies 포함)
-RUN pnpm install --frozen-lockfile
+# 모든 의존성 설치 (devDependencies 포함, postinstall 스크립트는 스킵)
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY --from=builder /app/out/full/ .
 


### PR DESCRIPTION


## 📌 이슈 번호

## 🛠️ 작업 내용

- [X]  pnpm install 할 때 postinstall 스크립트가 prisma generate를 실행하는데, 이 시점에는 아직 소스 코드가 복사되지 않아서 schema.prisma 파일이 없어서 나는 에러 해결
## 🤔 고민했던 부분

## 🆘 도움이 필요한 부분
