### PR TITLE
fix: nginx 시작시에 서버 컨테이너 준비 에러 해결

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,11 +1,21 @@
 events {}
 
 http {
+  resolver 127.0.0.11 valid=10s;
+
+  upstream backend {
+    server server:3000;
+  }
+
+  upstream frontend {
+    server web:3001;
+  }
+
   server {
     listen 80;
 
     location /api {
-      proxy_pass http://server:3000;
+      proxy_pass http://backend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -13,7 +23,7 @@ http {
     }
 
     location / {
-      proxy_pass http://web:3001;
+      proxy_pass http://frontend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- nginx가 시작할 때 server 컨테이너가 아직 준비되지 않아서 DNS 해석에 실패합니다. Docker Compose의 depends_on은 컨테이너 시작만 기다리고, 서비스가 실제로 준비될 때까지 기다리지 않습니다.
- resolver 127.0.0.11 추가 - Docker 내부 DNS 사용 upstream 블록으로 분리 - DNS 해석 타이밍 문제 해결

## 📌 이슈 번호

## 🛠️ 작업 내용

- [ ]
- [ ]

## 🤔 고민했던 부분

## 🆘 도움이 필요한 부분
