### PR TITLE
fix: 변수 방식으로 수정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,21 +1,14 @@
 events {}
 
 http {
-  resolver 127.0.0.11 valid=10s;
-
-  upstream backend {
-    server server:3000;
-  }
-
-  upstream frontend {
-    server web:3001;
-  }
+  resolver 127.0.0.11 valid=10s ipv6=off;
 
   server {
     listen 80;
 
     location /api {
-      proxy_pass http://backend;
+      set $backend server:3000;
+      proxy_pass http://$backend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -23,7 +16,8 @@ http {
     }
 
     location / {
-      proxy_pass http://frontend;
+      set $frontend web:3001;
+      proxy_pass http://$frontend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION


## 📌 이슈 번호

## 🛠️ 작업 내용

- [x] set $variable 방식은 nginx가 시작할 때 호스트명을 검증하지 않고, 요청이 들어올 때 동적으로 DNS를 해석

## 🤔 고민했던 부분
Docker Compose의 depends_on은 컨테이너의 **'시작(Start)'**만 보장할 뿐, 내부의 애플리케이션(Node.js 등)이 **'준비(Ready)'**될 때까지 기다려주지 않습니다.

현상: Nginx가 부팅될 때 server 컨테이너가 아직 구동 중이면, Nginx는 server라는 도메인 주소를 찾지 못해(Name not resolved) 아예 실행에 실패하거나 중단되는 현상이 발생합니다.

### 개선 방안: 동적 DNS 리졸버 및 Upstream 적용
Nginx가 실행 시점에 고정된 IP를 찾는 대신, 런타임에 Docker의 내부 DNS를 통해 서비스를 동적으로 찾도록 구조를 변경했습니다.


## 🆘 도움이 필요한 부분
