### PR TITLE
fix: env 환경변수와 포트 번호 일치 시켜주기

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ http {
     listen 80;
 
     location /api {
-      set $backend server:3000;
+      set $backend server:3001;
       proxy_pass http://$backend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -16,7 +16,7 @@ http {
     }
 
     location / {
-      set $frontend web:3001;
+      set $frontend web:3000;
       proxy_pass http://$frontend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 📌 이슈 번호

## 🛠️ 작업 내용

- [x]도커 파일의 포트 번호 수정 

## 🤔 고민했던 부분
계속해서 NginX에서 서버 컨테이너를 찾지 못하는 에러가 발생했는데 에러 메세지를 보니 서버 포트를 계속 3000으로 찾고 있다는 것을 발견했습니다.
이후 깃허브 시크릿을 통해 포함된 환경 변수와 도커 파일의 포트 번호 일치하지 않는다는 사실을 알게 되어 수정해주었습니다. 

## 🆘 도움이 필요한 부분
