### PR TITLE
fix: nginx의 기본 업로드 제한 에러 해결

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,7 @@ events {}
 
 http {
   resolver 127.0.0.11 valid=10s ipv6=off;
+  client_max_body_size 300M;
 
   server {
     listen 80;


### PR DESCRIPTION


## 📌 이슈 번호

## 🛠️ 작업 내용

- [x] nginx의 기본 업로드 제한(1MB)을 우리 서비스에 맞게 300MB로 확장해줬습니다.

## 🤔 고민했던 부분
정상 배포된 서버에서 zip파일 업로드를 실행하는데 계속 서버에서 용량 초과 에러가 발생했습니다. 
알고보니 nginx 자체에 기본 업로드 제한이 있어서 에러가 발생하는 것이었고, 용량을 우리 서비스에 맞게 확장해주었습니다 .

## 🆘 도움이 필요한 부분
