### PR TITLE
fix: 도커 파일에서 prisma.config를 참조하지 않아서 발생하는 에러 해결

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -56,6 +56,7 @@ COPY --from=installer --chown=nestjs:nodejs /app/apps/server/node_modules ./apps
 COPY --from=installer --chown=nestjs:nodejs /app/apps/server/dist ./apps/server/dist
 COPY --from=installer --chown=nestjs:nodejs /app/apps/server/prisma ./apps/server/prisma
 COPY --from=installer --chown=nestjs:nodejs /app/apps/server/package.json ./apps/server/package.json
+COPY --from=installer --chown=nestjs:nodejs /app/apps/server/prisma.config.ts ./apps/server/prisma.config.ts
 
 USER nestjs
 


### PR DESCRIPTION
## 📌 이슈 번호

## 🛠️ 작업 내용

- [x] 도커 파일에 prisma.config 파일도 참조하여 컨테이너를 만들도록 수정해주었습니다. 

## 🤔 고민했던 부분
배포 스크립트에서 `npx prisma migrate deploy `명령어를 실행할 때, 이 설정 파일이 컨테이너 내부에 없으면 연결이 안되기에  에러와 함께 마이그레이션이 중단됩니다.
도커 파일에서 config 파일을 복사하도록 해주었습니다 
## 🆘 도움이 필요한 부분
