### PR TITLE
[FE] 깃허브 업로드 탭 ui 깨짐 + 분석 페이지 스크롤 바 추가 

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="grid min-h-full place-content-center">
       <section className="mx-auto w-full max-w-6xl px-6 py-8">
         {/* 상단 제목 */}
-        <div className="mb-16 text-center">
+        <div className="mt-60 mb-16 text-center lg:mt-0">
           <h2 className="text-heading mb-3 text-3xl leading-tight font-black md:text-4xl">
             프로젝트 구조를{" "}
             <span className="from-accent-dim to-primary bg-linear-to-r bg-clip-text text-transparent">

--- a/apps/web/src/components/analyzing/AnalyzingView.tsx
+++ b/apps/web/src/components/analyzing/AnalyzingView.tsx
@@ -165,7 +165,7 @@ export default function AnalyzingView({ projectId }: AnalyzingViewProps) {
   };
 
   return (
-    <div className="bg-page flex h-full flex-col items-center justify-center">
+    <div className="thin-scrollbar bg-page flex h-full flex-col items-center justify-center overflow-y-auto">
       <div className="w-full max-w-2xl px-6">
         {/* 제목 영역 */}
         <div className="mb-8 text-center">

--- a/apps/web/src/components/layout/FileItem.tsx
+++ b/apps/web/src/components/layout/FileItem.tsx
@@ -7,6 +7,7 @@ import { FileNode } from "@/utils/pathTree";
 import { useExplorerStore } from "@/stores/useExplorerStore";
 import { useVisualizationStore } from "@/store/useVisualizationStore";
 import { maybeDecode } from "@/utils/url";
+import { useDebouncedPrefetch } from "@/hooks/useDebouncedPrefetch";
 
 interface FileItemProps {
   node: FileNode;
@@ -29,6 +30,7 @@ export const FileItem = ({ node, depth }: FileItemProps) => {
   const setCachedCode = useVisualizationStore((s) => s.setCachedCode);
 
   const indicatedPaths = useExplorerStore((s) => s.indicatedPaths);
+  const { debouncedPrefetch, cancel: cancelPrefetch } = useDebouncedPrefetch(150);
 
   const isHighlighted = highlightedPaths.includes(node.path);
   const isIndicated = !isFolder && indicatedPaths.has(node.path);
@@ -43,22 +45,29 @@ export const FileItem = ({ node, depth }: FileItemProps) => {
 
   const handleMouseEnter = useCallback(() => {
     if (!isClickable || isFolder || !node.path || !params.analysisId) return;
-    const decoded = maybeDecode(node.path) ?? node.path;
-    if (
-      useVisualizationStore.getState().getCachedCode(params.analysisId, decoded)
-    )
-      return;
 
-    (async () => {
-      try {
-        const { getCode } = await import("@/api/code");
-        const result = await getCode(params.analysisId, decoded);
-        setCachedCode(params.analysisId, decoded, result.markdownContent);
-      } catch {
-        /* ignore */
-      }
-    })();
-  }, [isClickable, isFolder, node.path, params.analysisId, setCachedCode]);
+    debouncedPrefetch(() => {
+      const decoded = maybeDecode(node.path) ?? node.path;
+      if (
+        useVisualizationStore.getState().getCachedCode(params.analysisId, decoded)
+      )
+        return;
+
+      (async () => {
+        try {
+          const { getCode } = await import("@/api/code");
+          const result = await getCode(params.analysisId, decoded);
+          setCachedCode(params.analysisId, decoded, result.markdownContent);
+        } catch {
+          /* ignore */
+        }
+      })();
+    });
+  }, [isClickable, isFolder, node.path, params.analysisId, setCachedCode, debouncedPrefetch]);
+
+  const handleMouseLeave = useCallback(() => {
+    cancelPrefetch();
+  }, [cancelPrefetch]);
 
   useEffect(() => {
     if (shouldExpand) {
@@ -113,6 +122,7 @@ export const FileItem = ({ node, depth }: FileItemProps) => {
           ref={itemRef}
           onClick={handleClick}
           onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
           title={node.path}
           className={`group flex items-center gap-1 px-2 py-1 pr-4 text-sm select-none ${
             isHighlighted

--- a/apps/web/src/components/result/visualization/VisualizationView.tsx
+++ b/apps/web/src/components/result/visualization/VisualizationView.tsx
@@ -44,7 +44,7 @@ interface VisualizationViewProps {
 
 export default function VisualizationView({
   visualizationId,
-  analysisId,
+
   onNodeClick,
   onPaneClick,
   initialNodes = [],
@@ -156,6 +156,7 @@ export default function VisualizationView({
       clearHighlightedPaths,
       setHighlightedPaths,
       setSelectedNodeId,
+      setFocusTargetType,
       router,
       pathname,
       searchParams,
@@ -200,7 +201,7 @@ export default function VisualizationView({
       setIsResetting(false);
     }
   }, [
-    analysisId,
+    visualizationId,
     setNodes,
     setEdges,
     setSelectedNodeId,

--- a/apps/web/src/components/result/visualization/nodes/BaseNode.tsx
+++ b/apps/web/src/components/result/visualization/nodes/BaseNode.tsx
@@ -41,20 +41,21 @@ export default function BaseNode({
 
   // 호버 시 프리패치 (디바운싱 적용)
   const handleMouseEnter = useCallback(() => {
-    if (!isHighlighted || !data.path || !params.analysisId) return;
+    const path = data.path;
+    const analysisId = params.analysisId;
+    if (!isHighlighted || !path || !analysisId) return;
+
+    const decoded = maybeDecode(path) ?? path;
 
     debouncedPrefetch(() => {
-      const decoded = maybeDecode(data.path) ?? data.path;
-      if (
-        useVisualizationStore.getState().getCachedCode(params.analysisId, decoded)
-      )
+      if (useVisualizationStore.getState().getCachedCode(analysisId, decoded))
         return;
 
       (async () => {
         try {
           const { getCode } = await import("@/api/code");
-          const result = await getCode(params.analysisId, decoded);
-          setCachedCode(params.analysisId, decoded, result.markdownContent);
+          const result = await getCode(analysisId, decoded);
+          setCachedCode(analysisId, decoded, result.markdownContent);
         } catch {
           /* ignore */
         }

--- a/apps/web/src/components/result/visualization/nodes/BaseNode.tsx
+++ b/apps/web/src/components/result/visualization/nodes/BaseNode.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useCallback } from "react";
 import { Handle, Position, NodeProps, type Node } from "@xyflow/react";
 import { useParams } from "next/navigation";
 import { type BaseNodeData } from "@/utils/layouts/layoutSettings";
 import { useVisualizationStore } from "@/store/useVisualizationStore";
 import { maybeDecode } from "@/utils/url";
+import { useDebouncedPrefetch } from "@/hooks/useDebouncedPrefetch";
 
 export default function BaseNode({
   data,
@@ -26,6 +28,7 @@ export default function BaseNode({
   const isCategoryHeader = groups === "CATEGORY_HEADER";
   const params = useParams<{ analysisId: string }>();
   const setCachedCode = useVisualizationStore((s) => s.setCachedCode);
+  const { debouncedPrefetch, cancel: cancelPrefetch } = useDebouncedPrefetch(150);
 
   // 하이라이트 여부
   const isHighlighted = !!highlightClass;
@@ -36,25 +39,32 @@ export default function BaseNode({
     return "16px";
   };
 
-  // 호버 시 프리패치
-  const handleMouseEnter = () => {
+  // 호버 시 프리패치 (디바운싱 적용)
+  const handleMouseEnter = useCallback(() => {
     if (!isHighlighted || !data.path || !params.analysisId) return;
-    const decoded = maybeDecode(data.path) ?? data.path;
-    if (
-      useVisualizationStore.getState().getCachedCode(params.analysisId, decoded)
-    )
-      return;
 
-    (async () => {
-      try {
-        const { getCode } = await import("@/api/code");
-        const result = await getCode(params.analysisId, decoded);
-        setCachedCode(params.analysisId, decoded, result.markdownContent);
-      } catch {
-        /* ignore */
-      }
-    })();
-  };
+    debouncedPrefetch(() => {
+      const decoded = maybeDecode(data.path) ?? data.path;
+      if (
+        useVisualizationStore.getState().getCachedCode(params.analysisId, decoded)
+      )
+        return;
+
+      (async () => {
+        try {
+          const { getCode } = await import("@/api/code");
+          const result = await getCode(params.analysisId, decoded);
+          setCachedCode(params.analysisId, decoded, result.markdownContent);
+        } catch {
+          /* ignore */
+        }
+      })();
+    });
+  }, [isHighlighted, data.path, params.analysisId, setCachedCode, debouncedPrefetch]);
+
+  const handleMouseLeave = useCallback(() => {
+    cancelPrefetch();
+  }, [cancelPrefetch]);
 
   const baseStyle: React.CSSProperties = {
     width: `${width}px`,
@@ -102,6 +112,7 @@ export default function BaseNode({
       style={baseStyle}
       className={containerClasses}
       onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <Handle
         type="target"

--- a/apps/web/src/components/upload/GithubUploadTab.tsx
+++ b/apps/web/src/components/upload/GithubUploadTab.tsx
@@ -105,73 +105,74 @@ export default function GithubUploadTab() {
         </div>
       </div>
 
-      {/* URL 확인 버튼: 로딩 중 / 미확인 / 확인 완료(파란색) */}
-      {!projectId ? (
-        <button
-          onClick={handleConfirm}
-          disabled={!githubUrl}
-          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-subtle px-5 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-muted hover:shadow-md disabled:cursor-not-allowed disabled:bg-hover disabled:text-muted disabled:shadow-none"
-        >
-          {loading ? (
-            <>
-              <svg
-                className="h-5 w-5 animate-spin"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
-              {GITHUB_UPLOAD.LOADING_MESSAGE}
-            </>
-          ) : (
-            <>
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              URL 확인
-            </>
-          )}
-        </button>
-      ) : (
-        <div className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-500 px-6 py-4 text-base font-semibold text-white shadow-sm">
-          <svg
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+      {/* URL 확인 버튼: 에러 시 숨김 / 로딩 중 / 미확인 / 확인 완료(파란색) */}
+      {!errorMessage &&
+        (!projectId ? (
+          <button
+            onClick={handleConfirm}
+            disabled={!githubUrl}
+            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-subtle px-5 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-muted hover:shadow-md disabled:cursor-not-allowed disabled:bg-hover disabled:text-muted disabled:shadow-none"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          확인 완료
-        </div>
-      )}
+            {loading ? (
+              <>
+                <svg
+                  className="h-5 w-5 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                {GITHUB_UPLOAD.LOADING_MESSAGE}
+              </>
+            ) : (
+              <>
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                URL 확인
+              </>
+            )}
+          </button>
+        ) : (
+          <div className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-500 px-5 py-3 text-sm font-semibold text-white shadow-sm">
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            확인 완료
+          </div>
+        ))}
 
       {/* 분석 시작하기 버튼 - 항상 표시, URL 확인 시 활성화 */}
       <button

--- a/apps/web/src/components/upload/Uploader.tsx
+++ b/apps/web/src/components/upload/Uploader.tsx
@@ -13,11 +13,13 @@ export default function Uploader() {
   return (
     <div>
       {/* 탭 메뉴 */}
-      <div className="relative mb-4 flex rounded-xl bg-page/50 p-1">
+      <div className="bg-page/50 relative mb-4 flex rounded-xl p-1">
         {/* 슬라이딩 배경 */}
         <div
-          className={`absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg bg-hover shadow-sm transition-transform duration-300 ease-in-out ${
-            activeTab === "zip" ? "translate-x-1" : "translate-x-[calc(100%+4px)]"
+          className={`bg-hover absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg shadow-sm transition-transform duration-300 ease-in-out ${
+            activeTab === "zip"
+              ? "translate-x-1"
+              : "translate-x-[calc(100%+4px)]"
           }`}
         />
         <button
@@ -44,7 +46,9 @@ export default function Uploader() {
         <button
           onClick={() => setActiveTab("github")}
           className={`relative z-10 flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg px-6 py-3 text-sm font-medium transition-colors duration-300 ${
-            activeTab === "github" ? "text-accent" : "text-muted hover:text-body"
+            activeTab === "github"
+              ? "text-accent"
+              : "text-muted hover:text-body"
           }`}
         >
           <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">

--- a/apps/web/src/hooks/useDebouncedPrefetch.ts
+++ b/apps/web/src/hooks/useDebouncedPrefetch.ts
@@ -1,0 +1,24 @@
+import { useRef, useCallback } from "react";
+
+export function useDebouncedPrefetch(delay: number = 150) {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const debouncedPrefetch = useCallback(
+    (callback: () => void) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(callback, delay);
+    },
+    [delay],
+  );
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  return { debouncedPrefetch, cancel };
+}


### PR DESCRIPTION
## 📌 이슈 번호
 - closes #114
## 🛠️ 작업 내용

- [x] 깃허브 업로드 탭 ui 깨짐 
- [x] 분석 페이지 스크롤 바 추가 
- [x] 프리패치 디바운싱 적용 

## 🤔 고민했던 부분
### hover시 즉시 요청 방식 수정
기존에는 빠르게 스크롤을 하며 호버되는 파일에 대해서도 프리패치가 적용이 됐는데, 디바운싱을 적용하여 
```
[빠르게 스크롤] → 파일 A, B, C, D 지나감 → 요청 0개 
[파일 E에서 멈춤] → 150ms 후 → 프리패치 1개 (의도한 파일만)
```
사용자가 의도한 파일만 프리패치할 수 있도록 수정하였습니다. 
디바운싱을 적용하는 경우 스크롤하며 무의미하게 호버가 되는 파일에 대한 요청 자체를 막고, 중복 요청도 자연스럽게 방지할 수 있습니다. 
 
## 🆘 도움이 필요한 부분