### PR TITLE
[FE] 상세 설명창 UI 수정 

### DIFF
--- a/apps/web/src/components/layout/Guide.tsx
+++ b/apps/web/src/components/layout/Guide.tsx
@@ -1,4 +1,3 @@
-// TODO: 안내 문구 표현 알기 쉽게 변경하기
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
@@ -13,6 +12,49 @@ import { useGuideStore } from "@/stores/useGuideStore";
 import { useVisualizationStore } from "@/store/useVisualizationStore";
 import { useSearchParams } from "next/navigation";
 import { useReactFlow } from "@xyflow/react";
+import {
+  HiMiniDocumentDuplicate,
+  HiMiniRectangleGroup,
+  HiUser,
+  HiStar,
+  HiRocketLaunch,
+  HiChatBubbleOvalLeftEllipsis,
+  HiLink,
+} from "react-icons/hi2";
+
+/**
+ * 가이드 내부 스타일을 위한 공통 레이아웃 컴포넌트
+ */
+const GuideStep = ({
+  title,
+  icon,
+  children,
+  tip,
+}: {
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  tip?: string;
+}) => (
+  <div className="flex flex-col gap-2 p-1 text-left">
+    <div className="mb-1 flex items-center gap-2 border-b border-slate-100 pb-3">
+      {icon && (
+        <span className="flex items-center justify-center p-2">{icon}</span>
+      )}
+      <h3 className="text-lg font-bold tracking-tight text-slate-800">
+        {title}
+      </h3>
+    </div>
+    <div className="text-[14.5px] leading-relaxed text-slate-600">
+      {children}
+    </div>
+    {tip && (
+      <div className="mt-3 rounded-xl border border-blue-100/50 bg-blue-50/50 p-3 text-[13px] leading-5 text-blue-700">
+        {tip}
+      </div>
+    )}
+  </div>
+);
 
 export default function Guide() {
   const params = useSearchParams();
@@ -45,10 +87,15 @@ export default function Guide() {
         {
           target: "#folder-sidebar",
           content: (
-            <div className="text-left">
-              <h3 className="text-lg font-bold">📂 파일 탐색기</h3>
-              <p>다른 파일의 코드를 보고 싶다면 선택하세요.</p>
-            </div>
+            <GuideStep
+              title="파일 탐색기"
+              icon={
+                <HiMiniDocumentDuplicate size={22} className="text-blue-500" />
+              }
+              tip="마커가 표시된 파일은 AI 코드 요약이 포함되어 있습니다."
+            >
+              <p>전체 소스코드 파일 목록을 확인합니다.</p>
+            </GuideStep>
           ),
           placement: "right",
           disableBeacon: true,
@@ -56,25 +103,26 @@ export default function Guide() {
         {
           target: "#result-tabs-nav",
           content: (
-            <div className="text-left">
-              <h3 className="text-lg font-bold">🔄 시각화로 돌아가기</h3>
-              <p>
-                Visual Graph 탭을 누르면
-                <br />
-                다이어그램 화면으로 돌아갑니다.
-              </p>
-            </div>
+            <GuideStep
+              title="시각화로 돌아가기"
+              icon={
+                <HiMiniRectangleGroup className="text-emerald-600" size={20} />
+              }
+            >
+              <p>시각화 탭을 클릭하면 다시 다이어그램 화면으로 이동합니다.</p>
+            </GuideStep>
           ),
           placement: "bottom",
         },
         {
           target: "#header-export-btn",
           content: (
-            <div className="text-center">
-              <h3 className="text-lg font-bold">🔗 공유하기</h3>
-              <p>링크를 복사하여</p>
-              <p className="font-bold">분석 결과를 공유해보세요!</p>
-            </div>
+            <GuideStep
+              title="공유하기"
+              icon={<HiLink className="text-slate-500" size={20} />}
+            >
+              링크로 복사하여 분석 결과를 공유해보세요!
+            </GuideStep>
           ),
           placement: "bottom",
         },
@@ -85,10 +133,15 @@ export default function Guide() {
       {
         target: "#folder-sidebar",
         content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">📂 파일 탐색기</h3>
-            <p>전체 파일 목록을 확인하고 코드를 열람합니다.</p>
-          </div>
+          <GuideStep
+            title="파일 탐색기"
+            icon={
+              <HiMiniDocumentDuplicate size={22} className="text-blue-500" />
+            }
+            tip="마커가 표시된 파일은 AI 코드 요약이 포함되어 있습니다."
+          >
+            <p>전체 소스코드 파일 목록을 확인합니다.</p>
+          </GuideStep>
         ),
         placement: "right",
         disableBeacon: true,
@@ -96,92 +149,103 @@ export default function Guide() {
       {
         target: ".react-flow",
         content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">🗺️ 다이어그램 결과 확인</h3>
+          <GuideStep
+            title="다이어그램 탐색"
+            icon={
+              <HiMiniRectangleGroup size={22} className="text-emerald-600" />
+            }
+            tip="Shift + 드래그 시 특정 영역의 노드들을 한 번에 선택할 수 있습니다."
+          >
             <p>프로젝트 구조를 자유롭게 탐색하세요.</p>
-            <p className="mt-2 text-sm text-slate-500">
-              💡 좌측 하단의 <strong>[+, -, Fit, 잠금]</strong> 버튼으로 화면을
-              제어할 수 있습니다.
+            <p className="mt-2 text-sm font-medium text-slate-400 italic">
+              * 하단 컨트롤러: +, -, Fit, 잠금 기능 지원
             </p>
-            <p className="mt-2 text-sm text-slate-500">
-              💡 shift+드래깅 시 노드 영역을 선택할 수 있습니다.
-            </p>
-          </div>
+          </GuideStep>
         ),
         placement: "center",
       },
       {
         target: ".react-flow",
         content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">👤 유저 스토리</h3>
-            <p className="mt-2 text-sm text-slate-500">
-              프로젝트의 <strong>핵심 기능</strong>을 확인하세요.
-              <br />
-            </p>
+          <GuideStep
+            title="유저 스토리"
+            icon={<HiUser size={22} className="text-indigo-500" />}
+            tip=" 노드 클릭 시 연관 파일이 하이라이팅 됩니다."
+          >
+            <p>사용자 시점의 핵심 기능 흐름을 확인할 수 있습니다.</p>
+          </GuideStep>
+        ),
+        placement: "bottom",
+      },
+      {
+        target: ".react-flow",
+        content: (
+          <GuideStep
+            title="핵심 파일 트리"
+            icon={<HiStar size={22} className="text-amber-500" />}
+          >
+            <p>주요 폴더와 파일의 구조가 연결되어 표시됩니다.</p>
+            <ul className="mt-2 space-y-1.5 text-sm">
+              <li className="flex items-start gap-2">
+                <span className="text-slate-400">•</span>
+                <span>
+                  <strong>폴더(실선):</strong> 클릭 시 폴더 역할 확인
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-slate-400">•</span>
+                <span>
+                  <strong>파일(점선):</strong> 클릭 시 코드 요약 확인
+                </span>
+              </li>
+            </ul>
+          </GuideStep>
+        ),
+        placement: "bottom",
+      },
+      {
+        target: ".react-flow",
+        content: (
+          <GuideStep
+            title="기술 스택"
+            icon={<HiRocketLaunch size={22} className="text-rose-500" />}
+          >
             <p>
-              노드 클릭 시 <strong>유저 스토리</strong>와 연관된 폴더 및 파일을
-              확인할 수 있습니다.
+              FE, BE, DB, Infra 영역별로 사용된
+              <br />
+              주요 라이브러리와 기술을 확인할 수 있습니다.
             </p>
-          </div>
-        ),
-        placement: "bottom",
-      },
-      {
-        target: ".react-flow",
-        content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">🗂️ 핵심 파일트리</h3>
-            <p className="mt-2">
-              <strong>주요 폴더와 파일의 구조</strong>가 연결되어 표시됩니다.
-              폴더는 실선, 파일은 점선으로 연결됩니다.
-            </p>
-            <p className="mt-2 text-sm text-slate-500">
-              <b>폴더 노드</b>를 클릭하면 해당 폴더의 역할을 확인할 수 있습니다.
-            </p>
-            <p className="mt-2 text-sm text-slate-500">
-              <b>파일 노드</b>를 클릭하면 코드 요약 내용을 확인할 수 있습니다.
-            </p>
-          </div>
-        ),
-        placement: "bottom",
-      },
-      {
-        target: ".react-flow",
-        content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">💻 기술 스택</h3>
-            <p className="mt-2 text-sm text-slate-500">
-              사용된 라이브러리와 기술을 확인합니다.
-            </p>
-            <p>FE, BE, DB, INFRA에 해당하는 기술을 확인할 수 있습니다.</p>
-          </div>
+          </GuideStep>
         ),
         placement: "bottom",
       },
       {
         target: "#details-panel",
         content: (
-          <div className="text-left">
-            <h3 className="text-lg font-bold">🔎 프로젝트 상세 설명</h3>
-            <p>
-              <strong>프로젝트의 전체 개요</strong>를 한눈에 확인하세요.
-            </p>
-            <p className="mt-2 text-sm text-slate-500">
-              💡 다이어그램에서 노드를 클릭하면 폴더 역할이 자동으로 표시됩니다.
-            </p>
-          </div>
+          <GuideStep
+            title="상세 설명 패널"
+            icon={
+              <HiChatBubbleOvalLeftEllipsis
+                size={22}
+                className="text-sky-400"
+              />
+            }
+            tip="하단 버튼을 통해 언제든 열고 닫을 수 있습니다."
+          >
+            <p>프로젝트의 목적, 개요 등 상세 정보를 확인하세요.</p>
+          </GuideStep>
         ),
         placement: "left",
       },
       {
         target: "#header-export-btn",
         content: (
-          <div className="text-center">
-            <h3 className="text-lg font-bold">🔗 공유하기</h3>
-            <p>링크를 복사하여</p>
-            <p className="font-bold">분석 결과를 공유해보세요!</p>
-          </div>
+          <GuideStep
+            title="공유하기"
+            icon={<HiLink className="text-slate-500" size={20} />}
+          >
+            링크로 복사하여 분석 결과를 공유해보세요!
+          </GuideStep>
         ),
         placement: "bottom",
       },
@@ -272,10 +336,29 @@ export default function Guide() {
           zIndex: 10000,
           primaryColor: "#0ea5e9",
           textColor: "#334155",
-          overlayColor: "rgba(0, 0, 0, 0.6)",
+          overlayColor: "rgba(15, 23, 42, 0.65)",
+          backgroundColor: "#ffffff",
         },
         spotlight: {
-          borderRadius: "12px",
+          borderRadius: "16px",
+        },
+        tooltip: {
+          borderRadius: "16px",
+          padding: "16px",
+        },
+        buttonNext: {
+          borderRadius: "8px",
+          fontWeight: 600,
+          padding: "8px 16px",
+        },
+        buttonBack: {
+          marginRight: 10,
+          fontSize: 14,
+          color: "#64748b",
+        },
+        buttonClose: {
+          marginTop: "10px",
+          marginRight: "10px",
         },
       }}
       locale={{

--- a/apps/web/src/components/result/visualization/NodeDetails.tsx
+++ b/apps/web/src/components/result/visualization/NodeDetails.tsx
@@ -54,8 +54,8 @@ export default function NodeDetails({
       </div>
 
       <div className="thin-scrollbar flex-1 space-y-3 overflow-y-auto p-5">
-        <div className="space-y-1.5">
-          <h3 className="text-heading text-xl leading-tight font-bold">
+        <div className="mb-5">
+          <h3 className="text-heading mb-3 text-xl leading-tight font-bold">
             {node.label}
           </h3>
           <span className="border-primary/20 bg-primary/10 text-accent rounded border px-2 py-1 text-xs break-all">

--- a/apps/web/src/components/result/visualization/NodeDetails.tsx
+++ b/apps/web/src/components/result/visualization/NodeDetails.tsx
@@ -58,6 +58,9 @@ export default function NodeDetails({
           <h3 className="text-heading text-xl leading-tight font-bold">
             {node.label}
           </h3>
+          <span className="border-primary/20 bg-primary/10 text-accent rounded border px-2 py-1 text-xs break-all">
+            {node.path}
+          </span>
         </div>
         <div className="text-body text-sm leading-relaxed">
           <div

--- a/apps/web/src/components/result/visualization/NodeDetails.tsx
+++ b/apps/web/src/components/result/visualization/NodeDetails.tsx
@@ -5,6 +5,7 @@ import { IoClose } from "react-icons/io5";
 import { NodeData } from "@/types/visualization";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { HiOutlineFolder } from "react-icons/hi";
 
 export interface NodeDetailsProps {
   node: NodeData | null;
@@ -40,7 +41,10 @@ export default function NodeDetails({
   return (
     <div className="border-line bg-surface/90 flex h-full flex-col overflow-hidden rounded-xl border shadow-2xl backdrop-blur-md">
       <div className="border-line/50 flex items-center justify-between border-b p-4">
-        <h2 className="text-subtle text-sm font-bold">폴더 역할 상세</h2>
+        <span className="flex items-center gap-2">
+          <HiOutlineFolder size={24} />
+          <h2 className="text-heading text-lg font-bold">폴더 역할 상세</h2>
+        </span>
         <button
           onClick={onClose}
           className="text-subtle hover:text-heading cursor-pointer"
@@ -57,13 +61,7 @@ export default function NodeDetails({
         </div>
         <div className="text-body text-sm leading-relaxed">
           <div
-            className={`prose max-w-none ${isDark ? "prose-invert" : ""}
-              prose-headings:text-heading
-              prose-strong:text-heading
-              prose-code:bg-hover prose-code:text-body prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
-              prose-code:before:content-[''] prose-code:after:content-['']
-              prose-p:text-body
-              prose-li:text-body`}
+            className={`prose max-w-none ${isDark ? "prose-invert" : ""} prose-headings:text-heading prose-strong:text-heading prose-code:bg-hover prose-code:text-body prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-[''] prose-p:text-body prose-li:text-body`}
           >
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {

--- a/apps/web/src/components/result/visualization/ProjectDetails.tsx
+++ b/apps/web/src/components/result/visualization/ProjectDetails.tsx
@@ -3,6 +3,7 @@
 import { IoClose } from "react-icons/io5";
 // Fix: Import from types file instead of VisualizationClient
 import { ProjectDetailsData } from "@/types/visualization";
+import { HiOutlineDocumentSearch } from "react-icons/hi";
 
 interface ProjectDetailsProps {
   data: ProjectDetailsData;
@@ -13,7 +14,10 @@ export default function ProjectDetails({ data, onClose }: ProjectDetailsProps) {
   return (
     <div className="border-line bg-surface/90 flex h-full flex-col rounded-xl border shadow-2xl backdrop-blur-md">
       <div className="border-line flex items-center justify-between border-b p-4">
-        <h2 className="text-heading text-lg font-bold">프로젝트 상세</h2>
+        <span className="flex items-center gap-2">
+          <HiOutlineDocumentSearch size={25} />
+          <h2 className="text-heading text-lg font-bold">프로젝트 상세</h2>
+        </span>
         <button
           onClick={onClose}
           className="text-subtle hover:bg-hover hover:text-heading cursor-pointer rounded-md p-1 transition-colors"

--- a/apps/web/src/components/result/visualization/VisualizationClient.tsx
+++ b/apps/web/src/components/result/visualization/VisualizationClient.tsx
@@ -218,8 +218,8 @@ export default function VisualizationClient({
   }
 
   return (
-    <div>
-      <div className="bg-page relative h-full w-full overflow-hidden">
+    <div className="bg-page relative h-full w-full overflow-hidden">
+      <div>
         {/* 모바일/작은 화면 경고 메시지 */}
         <div className="absolute inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm md:hidden">
           <div className="bg-surface mx-4 max-w-md rounded-lg p-8 text-center shadow-2xl">
@@ -238,7 +238,7 @@ export default function VisualizationClient({
         </div>
       </div>
 
-      <div className="relative h-screen w-full">
+      <div className="relative h-full w-full">
         <VisualizationView
           visualizationId={visualizationId}
           analysisId={analysisId}

--- a/apps/web/src/hooks/useVisualizationFocus.ts
+++ b/apps/web/src/hooks/useVisualizationFocus.ts
@@ -20,12 +20,12 @@ export function useVisualizationFocus() {
       );
 
       if (focusTargetType === "STEP1") {
-        const groupNode = allNodes.find((n) => n.id === "group-STEP1");
+        const groupNode = allNodes.find((n) => n.id === "group-STEP1-label");
         if (groupNode) {
           const zoom = 0.6;
           const centerX =
             groupNode.position.x + (groupNode.data.width || 700) / 2;
-          const topY = groupNode.position.y - 300;
+          const topY = groupNode.position.y;
           const targetCenterY = topY + 350 / zoom;
 
           setCenter(centerX, targetCenterY, { zoom, duration: 1000 });
@@ -36,7 +36,7 @@ export function useVisualizationFocus() {
           const zoom = 0.5;
           const centerX =
             labelNode.position.x + (labelNode.data.width || 600) / 2;
-          const targetCenterY = labelNode.position.y + 150 / zoom;
+          const targetCenterY = labelNode.position.y + 200 / zoom;
 
           setCenter(centerX, targetCenterY, { zoom, duration: 1000 });
         }

--- a/apps/web/src/utils/transformNodes.ts
+++ b/apps/web/src/utils/transformNodes.ts
@@ -136,7 +136,7 @@ function transformStep2(apiNodes: ApiNode[]): Node<BaseNodeData>[] {
     type: "baseNode",
     position: {
       x: bounds.minX + bounds.width / 2 - LABEL_W / 2,
-      y: bounds.minY - 120,
+      y: bounds.minY - 180,
     },
     data: {
       label: "Project File Tree",


### PR DESCRIPTION
## 📌 이슈 번호
- #148 

## 🛠️ 작업 내용
<img width="1916" height="944" alt="image" src="https://github.com/user-attachments/assets/a39b03b5-e077-4f42-af4c-04da92427b6b" />

- 폴더 역할 상세 설명에 폴더 전체 경로 추가
- 사용법 내용 수정

## 🤔 고민했던 부분

## 🆘 도움이 필요한 부분