### PR TITLE
[FE] 코드탭 LCP 개선 

### DIFF
--- a/apps/web/src/app/result/[projectId]/[analysisId]/page.tsx
+++ b/apps/web/src/app/result/[projectId]/[analysisId]/page.tsx
@@ -1,6 +1,7 @@
 import ResultTabsClient from "@/components/result/ResultTabsClient";
 import { getVisualization, updateVisualization } from "@/api/visualization";
 import { getIntentions } from "@/api/intention";
+import { getCode } from "@/api/code";
 import { calculateInitialLayout } from "@/utils/layouts/layoutCalculator";
 import type { VisualizationResponse } from "@/api/visualization";
 import type { GetIntentionsResponse } from "@/types/intentionApi";
@@ -20,19 +21,24 @@ export default async function ResultPage({
 
   let initialVisualizationData: VisualizationResponse | null = null;
   let initialIntentionsData: GetIntentionsResponse | null = null;
+  let initialContent: string | null = null;
 
   let visualizationId = "";
 
   try {
-    const [vizData, intentionsData] = await Promise.all([
+    const [vizData, intentionsData, codeData] = await Promise.all([
       getVisualization(analysisId),
       getIntentions(analysisId),
+      initialFilePath
+        ? getCode(analysisId, initialFilePath).catch(() => null)
+        : Promise.resolve(null),
     ]);
 
     visualizationId = vizData.visualizationId;
 
     initialVisualizationData = vizData;
     initialIntentionsData = intentionsData;
+    initialContent = codeData?.markdownContent ?? null;
 
     // 레이아웃이 초기 상태일 때만 서버에서 계산 및 DB 업데이트
     if (vizData.layoutState === "INITIAL") {
@@ -63,6 +69,7 @@ export default async function ResultPage({
       analysisId={analysisId}
       initialTab={initialTab}
       initialFilePath={initialFilePath}
+      initialContent={initialContent}
       initialVisualizationData={initialVisualizationData}
       initialIntentionsData={initialIntentionsData}
     />

--- a/apps/web/src/components/result/ResultTabsClient.tsx
+++ b/apps/web/src/components/result/ResultTabsClient.tsx
@@ -25,6 +25,7 @@ type Props = {
   visualizationId: string;
   initialTab?: "code" | "visualization";
   initialFilePath?: string | null;
+  initialContent?: string | null;
   initialVisualizationData?: VisualizationResponse | null;
   initialIntentionsData?: GetIntentionsResponse | null;
 };
@@ -34,6 +35,7 @@ export default function ResultTabsClient({
   analysisId,
   initialTab = "visualization",
   initialFilePath = null,
+  initialContent = null,
   initialVisualizationData = null,
   initialIntentionsData = null,
 }: Props) {
@@ -105,7 +107,7 @@ export default function ResultTabsClient({
             : "pointer-events-none z-0 opacity-0"
         }`}
       >
-        {codeLoaded && <CodeView initialFilePath={initialFilePath} />}
+        {codeLoaded && <CodeView initialFilePath={initialFilePath} initialContent={initialContent} />}
       </div>
 
       <div

--- a/apps/web/src/components/result/code/CodeView.tsx
+++ b/apps/web/src/components/result/code/CodeView.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { useParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { SyntaxHighlighter } from "./SyntaxHighlighter";
 import {
   oneDark,
   oneLight,

--- a/apps/web/src/components/result/code/SyntaxHighlighter.ts
+++ b/apps/web/src/components/result/code/SyntaxHighlighter.ts
@@ -1,0 +1,68 @@
+import { PrismLight } from "react-syntax-highlighter";
+import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
+import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
+import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
+import java from "react-syntax-highlighter/dist/esm/languages/prism/java";
+import c from "react-syntax-highlighter/dist/esm/languages/prism/c";
+import cpp from "react-syntax-highlighter/dist/esm/languages/prism/cpp";
+import csharp from "react-syntax-highlighter/dist/esm/languages/prism/csharp";
+import go from "react-syntax-highlighter/dist/esm/languages/prism/go";
+import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
+import kotlin from "react-syntax-highlighter/dist/esm/languages/prism/kotlin";
+import swift from "react-syntax-highlighter/dist/esm/languages/prism/swift";
+import dart from "react-syntax-highlighter/dist/esm/languages/prism/dart";
+import ruby from "react-syntax-highlighter/dist/esm/languages/prism/ruby";
+import php from "react-syntax-highlighter/dist/esm/languages/prism/php";
+import css from "react-syntax-highlighter/dist/esm/languages/prism/css";
+import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
+import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
+import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
+import sql from "react-syntax-highlighter/dist/esm/languages/prism/sql";
+import docker from "react-syntax-highlighter/dist/esm/languages/prism/docker";
+import markdown from "react-syntax-highlighter/dist/esm/languages/prism/markdown";
+
+const languages: Record<string, unknown> = {
+  javascript,
+  js: javascript,
+  typescript,
+  ts: typescript,
+  tsx,
+  jsx,
+  python,
+  py: python,
+  java,
+  c,
+  cpp,
+  csharp,
+  cs: csharp,
+  go,
+  rust,
+  rs: rust,
+  kotlin,
+  kt: kotlin,
+  swift,
+  dart,
+  ruby,
+  rb: ruby,
+  php,
+  css,
+  json,
+  bash,
+  sh: bash,
+  shell: bash,
+  yaml,
+  yml: yaml,
+  sql,
+  docker,
+  dockerfile: docker,
+  markdown,
+  md: markdown,
+};
+
+for (const [name, lang] of Object.entries(languages)) {
+  PrismLight.registerLanguage(name, lang);
+}
+
+export { PrismLight as SyntaxHighlighter };


### PR DESCRIPTION
## 📌 이슈 번호
- closes #152 
## 🛠️ 작업 내용

- [x] [refactor: 하이라이터 라이브러리 선택적 로드로 변경](https://github.com/boostcampwm2025/web28-show-me-the-gujo/commit/d91fef7c392c8cdb005b570dc4a805e244845bf7)[refactor: 하이라이터 라이브러리 선택적 로드로 변경](https://github.com/boostcampwm2025/web28-show-me-the-gujo/commit/d91fef7c392c8cdb005b570dc4a805e244845bf7)
- [x] [refactor: 초기 경로가 있는 경우 서버컴포넌트에서 데이터 패치](https://github.com/boostcampwm2025/web28-show-me-the-gujo/commit/2092af53d069f2ff1e96a26467c6ca3ae9420837)[refactor: 초기 경로가 있는 경우 서버컴포넌트에서 데이터 패치](https://github.com/boostcampwm2025/web28-show-me-the-gujo/commit/2092af53d069f2ff1e96a26467c6ca3ae9420837)

## 🤔 고민했던 부분
### TBT 및 LCP 줄이기
<img width="1748" height="1014" alt="image" src="https://github.com/user-attachments/assets/595b75c5-475e-42e5-a035-975bb5ab4e58" />

코드탭의 TBT가 다소 크게 측정이 되었다.
원인을 분석한 결과, 하이라이트 라이브러리가 모든 언어를 번들에 포함하고 있어 JS 번들 사이즈가 크고, 이로 인해 JS 파싱 단계에서 메인 스레드를 오래 점유하여 `TBT(Total Blocking Time)`가 높아지는 것이 문제였다.
###  하이라이트 라이브러리 번들 최적화
모든 언어를 로드하던 방식에서, 실제로 필요한 일부 언어만 로드하도록 수정하여 번들 사이즈를 줄이고 TBT를 개선했다.

그리고 LCP문제는 Lighthouse의 측정 방식 자체에서 오는 문제임을 확인했다.
Lighthouse는 URL에 직접 접속하여 페이지를 로드하는 콜드 로드 환경에서 LCP를 측정한다. 이 경우 기존에 프리패치해둔 캐시가 존재하지 않기 때문에, 클라이언트에서 데이터를 페칭한 후에야 렌더링이 시작되는 워터폴이 그대로 발생한다. 기존에는 url에 filePath가 들어가있지만 캐시가 안되어있는 상황을 고려하지 못했는데, 실제 사용자도 다음과 같은 상황에서 동일한 콜드 로드를 경험한다.

> 새로고침 시 (메모리 캐시가 증발)
> URL을 공유받아 해당 페이지에 처음 접속할 때

### 서버 컴포넌트에서 코드 데이터 패치
이를 해결하기 위해, filePath가 존재하는 경우 서버 컴포넌트에서 코드 데이터를 미리 페칭하여 내려주도록 수정했다. 이를 통해 콜드 로드 시에도 클라이언트에서 별도의 데이터 패칭 없이 바로 렌더링할 수 있게 되어 LCP가 개선된다.


### 개선 사항 LCP 1.9s
그리고 dev 모드가 아닌 빌드후에 프로덕션 모드로 lighthouse를 다시 측정해본 결과 LCP를 1.9s로 줄어든 것을 확인했다. 
<img width="1774" height="966" alt="image" src="https://github.com/user-attachments/assets/95b859d2-3f9d-4b2d-9b31-90814362a999" />

## 🆘 도움이 필요한 부분